### PR TITLE
9 Intermittent missing quadkey value

### DIFF
--- a/tile-id-api/internal/handler/identifiers.go
+++ b/tile-id-api/internal/handler/identifiers.go
@@ -3,7 +3,8 @@ package handler
 import "slices"
 
 func SortIdentifiers(allIdentifiers []string, firstValue string) []string {
-	ownAllIdentifiers := allIdentifiers[:]
+	ownAllIdentifiers := make([]string, len(allIdentifiers))
+	copy(ownAllIdentifiers, allIdentifiers)
 	slices.Sort(ownAllIdentifiers)
 	split := -1
 	for i, identifier := range ownAllIdentifiers {


### PR DESCRIPTION
Closes #9 

I was not able to duplicate this issue but I did find a race condition the definitely could have produced the observed issue.

`allIdentifiers[:]` does not copy the underlying array like `[:]` does in Python, it just creates a new slice that points the same underlying array as `allIdentifiers`. So `identifiers.SortIdentifiers()` was still sorting the elements in `allIdentifiers` despite the apparent attempt to make a copy.

This could definitely cause keys to go missing if requests are handled concurrently. You would have multiple handlers attempting to sort the same array at the same time.